### PR TITLE
Specify custom attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `null?` method to both parent class objects and null objects
+- Null objects now have default nil values for attributes of the mimic model class
+
+### Changed
+
+- `Null()` method switched to a keywoard `inherit:` option to inherit attributes from the parent class
 
 ## [0.1.0] - 2024-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `null?` method to both parent class objects and null objects
 - Null objects now have default nil values for attributes of the mimic model class
-
-### Changed
-
-- `Null()` method switched to a keywoard `inherit:` option to inherit attributes from the parent class
+- `Null()` method can now accept a hash of attribute names and values to assign to the null object
 
 ## [0.1.0] - 2024-10-23
 

--- a/lib/activerecord/null.rb
+++ b/lib/activerecord/null.rb
@@ -23,14 +23,15 @@ module ActiveRecord
     #
     #   Business.null # => #<Business::Null:0x0000000000000000>
     #
-    def Null(klass = self, &)
+    def Null(inherit: self, &)
       null_class = Class.new do
         include ::ActiveRecord::Null::Mimic
-        mimics klass
+        mimics inherit
 
         include Singleton
       end
       null_class.class_eval(&)
+      null_class.define_attribute_methods(inherit.attribute_names)
       const_set(:Null, null_class)
 
       define_singleton_method(:null) { null_class.instance }

--- a/lib/activerecord/null.rb
+++ b/lib/activerecord/null.rb
@@ -15,26 +15,48 @@ module ActiveRecord
     # Define a Null class for the given class.
     #
     # @example
-    #   class Business
+    #   class Business < ApplicationRecord
     #     Null do
     #       def name = "None"
     #     end
     #   end
     #
     #   Business.null # => #<Business::Null:0x0000000000000000>
+    #   Business.null.name # => "None"
     #
-    def Null(inherit: self, &)
+    #   class User < ApplicationRecord
+    #     Null([:name, :team_name] => "Unknown")
+    #   end
+    #
+    #   User.null.name # => "Unknown"
+    #   User.null.team_name # => "Unknown"
+    #
+    # @param inherit [Class] The class from which the Null object inherits attributes
+    # @param assignments [Array] The attributes to assign to the null object
+    def Null(inherit = self, assignments = {}, &)
+      if inherit.is_a?(Hash)
+        assignments = inherit
+        inherit = self
+      end
       null_class = Class.new do
         include ::ActiveRecord::Null::Mimic
         mimics inherit
 
         include Singleton
       end
-      null_class.class_eval(&)
-      null_class.define_attribute_methods(inherit.attribute_names)
-      const_set(:Null, null_class)
+      null_class.class_eval(&) if block_given?
 
-      define_singleton_method(:null) { null_class.instance }
+      nil_assignments = inherit.attribute_names
+      if assignments.any?
+        assignments.each do |attributes, value|
+          nil_assignments -= attributes
+          null_class.define_attribute_methods(attributes, value:)
+        end
+      end
+      null_class.define_attribute_methods(nil_assignments)
+      inherit.const_set(:Null, null_class)
+
+      inherit.define_singleton_method(:null) { null_class.instance }
     end
 
     def self.extended(base)

--- a/lib/activerecord/null/mimic.rb
+++ b/lib/activerecord/null/mimic.rb
@@ -17,6 +17,12 @@ module ActiveRecord
         def self.table_name = @mimic_model_class.to_s.tableize
 
         def self.primary_key = @mimic_model_class.primary_key
+
+        def self.define_attribute_methods(attribute_names, value: nil)
+          attribute_names.each do |attribute_name|
+            define_method(attribute_name) { value } unless method_defined?(attribute_name)
+          end
+        end
       end
 
       def mimic_model_class = self.class.mimic_model_class

--- a/lib/activerecord/null/mimic.rb
+++ b/lib/activerecord/null/mimic.rb
@@ -20,7 +20,13 @@ module ActiveRecord
 
         def self.define_attribute_methods(attribute_names, value: nil)
           attribute_names.each do |attribute_name|
-            define_method(attribute_name) { value } unless method_defined?(attribute_name)
+            unless method_defined?(attribute_name)
+              if value.is_a?(Proc)
+                define_method(attribute_name, &value)
+              else
+                define_method(attribute_name) { value }
+              end
+            end
           end
         end
       end

--- a/test/activerecord/test_null.rb
+++ b/test/activerecord/test_null.rb
@@ -86,6 +86,10 @@ class ActiveRecord::TestNull < Minitest::Spec
       expect(User.null.posts).must_be_kind_of ActiveRecord::Relation
       expect(User.null.posts.to_a).must_equal []
     end
+
+    it "has default nil values for attributes of the mimic model class" do
+      expect(User.null.team_name).must_be_nil
+    end
   end
 
   describe "Parent class object" do

--- a/test/activerecord/test_null.rb
+++ b/test/activerecord/test_null.rb
@@ -16,7 +16,7 @@ end
 class Post < ApplicationRecord
   belongs_to :user
 
-  Null()
+  Null([:description] => -> { "From the callable!" })
 end
 
 class User < ApplicationRecord
@@ -99,6 +99,10 @@ class ActiveRecord::TestNull < Minitest::Spec
 
     it "assigns the named attributes with the given values" do
       expect(User.null.team_name).must_equal "Unknown"
+    end
+
+    it "assigns callable values to attributes" do
+      expect(Post.null.description).must_equal "From the callable!"
     end
   end
 

--- a/test/activerecord/test_null.rb
+++ b/test/activerecord/test_null.rb
@@ -15,13 +15,15 @@ end
 
 class Post < ApplicationRecord
   belongs_to :user
+
+  Null()
 end
 
 class User < ApplicationRecord
   belongs_to :business
   has_many :posts
 
-  Null do
+  Null([:team_name, :other] => "Unknown") do
     def name = "None"
   end
 end
@@ -88,7 +90,15 @@ class ActiveRecord::TestNull < Minitest::Spec
     end
 
     it "has default nil values for attributes of the mimic model class" do
-      expect(User.null.team_name).must_be_nil
+      expect(Post.null.title).must_be_nil
+    end
+
+    it "creates a Null object without a block" do
+      expect(Post.null).must_be_instance_of Post::Null
+    end
+
+    it "assigns the named attributes with the given values" do
+      expect(User.null.team_name).must_equal "Unknown"
     end
   end
 

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -11,6 +11,7 @@ ActiveRecord::Schema.define do
 
   create_table :posts do |t|
     t.string :title
+    t.string :description
     t.references :user
   end
 end

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -5,6 +5,7 @@ ActiveRecord::Schema.define do
 
   create_table :users do |t|
     t.string :name
+    t.integer :team_name
     t.references :business
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,11 +3,10 @@
 require "simplecov" if ENV["CI"]
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "activerecord/null"
 
 require "active_record"
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
 load "test/support/schema.rb"
-
-require "activerecord/null"
 
 require "minitest/autorun"


### PR DESCRIPTION
By default, all attributes from the mimicked class will be set to `nil`.

But you can now pass a hash of attributes and values to return alternatives.

```ruby
class User < ApplicationRecord
  Null(
    [:name, :title] => "Unknown",
    [:description] => -> { "some calculation" }
  ) do
    def other_method = "Some other value"
  end
end
```