### PR TITLE
Add query constraint support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `null?` method to both parent class objects and null objects
 - Null objects now have default nil values for attributes of the mimic model class
 - `Null()` method can now accept a hash of attribute names and values to assign to the null object
+- `has_query_constraints?` method to null objects
+- `respond_to?` method to null objects
+- `_read_attribute` method to null objects
+- Null class now return false for `composite_primary_key?`

--- a/README.md
+++ b/README.md
@@ -48,6 +48,26 @@ It will even work with associations.
 User.null.posts # => []
 ```
 
+By default, the null object will have the same attributes as the original model and will return `nil` for all attributes.
+
+You can override this by passing a hash to the `Null` method where the key is an array of attributes and the value is the value to return for the attribute.
+
+```ruby
+class User < ApplicationRecord
+  Null([:name, :team_name] => "Unknown") do
+    def other_attribute = "Other"
+  end
+end
+```
+
+You may also pass a callable to the hash which will be used to determine the value for the attribute.
+
+```ruby
+class User < ApplicationRecord
+  Null([:name, :team_name] => -> { "Unknown" })
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/activerecord/null.rb
+++ b/lib/activerecord/null.rb
@@ -43,6 +43,16 @@ module ActiveRecord
         mimics inherit
 
         include Singleton
+
+        class << self
+          def method_missing(method, ...)
+            mimic_model_class.respond_to?(method) ? mimic_model_class.send(method, ...) : super
+          end
+
+          def respond_to_missing?(method, include_private = false)
+            mimic_model_class.respond_to?(method, include_private) || super
+          end
+        end
       end
       null_class.class_eval(&) if block_given?
 

--- a/lib/activerecord/null/mimic.rb
+++ b/lib/activerecord/null/mimic.rb
@@ -54,7 +54,7 @@ module ActiveRecord
 
       def persisted? = false
 
-      def has_query_constraints? = false
+      def _read_attribute(_) = nil
 
       def method_missing(method, ...)
         reflections = mimic_model_class.reflect_on_all_associations

--- a/lib/activerecord/null/mimic.rb
+++ b/lib/activerecord/null/mimic.rb
@@ -54,6 +54,8 @@ module ActiveRecord
 
       def persisted? = false
 
+      def has_query_constraints? = false
+
       def method_missing(method, ...)
         reflections = mimic_model_class.reflect_on_all_associations
         if (reflection = reflections.find { |r| r.name == method })

--- a/test/activerecord/test_null.rb
+++ b/test/activerecord/test_null.rb
@@ -37,7 +37,13 @@ class ActiveRecord::TestNull < Minitest::Spec
 
   describe ".has_query_constraints?" do
     it "returns false" do
-      expect(User.null.has_query_constraints?).must_equal false
+      expect(User::Null.has_query_constraints?).must_equal false
+    end
+  end
+
+  describe ".composite_primary_key?" do
+    it "returns false" do
+      expect(User::Null.composite_primary_key?).must_equal false
     end
   end
 
@@ -109,6 +115,14 @@ class ActiveRecord::TestNull < Minitest::Spec
 
     it "assigns callable values to attributes" do
       expect(Post.null.description).must_equal "From the callable!"
+    end
+
+    it "reads attributes and returns nil" do
+      expect(Post.null._read_attribute(:description)).must_be_nil
+    end
+
+    it "responds to mimic methods" do
+      expect(Post.null.respond_to?(:description)).must_equal true
     end
   end
 

--- a/test/activerecord/test_null.rb
+++ b/test/activerecord/test_null.rb
@@ -35,6 +35,12 @@ class ActiveRecord::TestNull < Minitest::Spec
     end
   end
 
+  describe ".has_query_constraints?" do
+    it "returns false" do
+      expect(User.null.has_query_constraints?).must_equal false
+    end
+  end
+
   describe "Null" do
     it "is null" do
       expect(User.null.null?).must_equal true


### PR DESCRIPTION
Using a null object in an association in tests with factory_bot lead to errors related to methods not defined. These changes support features needed to better act like an ActiveRecord object.